### PR TITLE
Strengthen pod security to meet baseline/restricted standards in the admission-control folder

### DIFF
--- a/admission-control/baseline-pod.yaml
+++ b/admission-control/baseline-pod.yaml
@@ -5,12 +5,33 @@ metadata:
   labels:
     app: baseline-test
 spec:
+  securityContext:
+    runAsNonRoot: true
+
   containers:
   - name: baseline-container
-    image: nginx:1.21
+    image: nginx:1.25
+
     securityContext:
       runAsUser: 1000
       runAsGroup: 1000
       allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+
+      capabilities:
+        drop:
+          - ALL
+
+      seccompProfile:
+        type: RuntimeDefault
+
     ports:
     - containerPort: 8080
+
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "200m"
+        memory: "256Mi"


### PR DESCRIPTION
This PR enhances the security posture of the baseline pod by aligning it with Kubernetes Pod Security Standards.

**Changes**

- Added `runAsNonRoot` at pod level
- Enabled `readOnlyRootFilesystem`
- Dropped all Linux capabilities
- Configured `seccompProfile `to `RuntimeDefault`
- Updated container image version
- Added CPU and memory resource limits

These updates reduce the attack surface and improve compliance with modern Kubernetes security best practices.