### PR TITLE
Update nginx Helm chart defaults for production readiness in the helm-and-kustomize folder

### DIFF
--- a/helm-and-kustomize/custom-nginx-values.yaml
+++ b/helm-and-kustomize/custom-nginx-values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 3
+replicaCount: 5
 
 service:
   type: NodePort
@@ -7,11 +7,11 @@ service:
 
 resources:
   limits:
-    cpu: 200m
-    memory: 256Mi
+    cpu: 500m
+    memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 250m
+    memory: 256Mi
 
 ingress:
   enabled: false


### PR DESCRIPTION
- Increased replicas from 3 → 5 for high availability.
- Updated CPU/memory requests & limits to better handle load.
- No changes to NodePort or ingress settings.